### PR TITLE
Change logic. Split master and slave operations.

### DIFF
--- a/lib/resty/limit/req.lua
+++ b/lib/resty/limit/req.lua
@@ -3,149 +3,163 @@
 
 local floor = math.floor
 local tonumber = tonumber
-
-
-local _M = { _VERSION = "0.01", OK = 1, BUSY = 2, FORBIDDEN = 3 }
-
-
-local redis_limit_req_script_sha
-local redis_limit_req_script = [==[
-local key = KEYS[1]
-local rate = tonumber(KEYS[2])
-local now, interval = tonumber(KEYS[3]), tonumber(KEYS[4])
-local burst = tonumber(KEYS[5])
-
-local excess, last, forbidden = 0, 0, 0
-
-local res = redis.pcall('GET', key)
-if type(res) == "table" and res.err then
-    return {err=res.err}
+local cjson = require("cjson")
+local redis = nil
+if not package.loaded['redis'] then
+    local ok
+    ok, redis = pcall(require, "resty.redis")
+    if not ok then
+        ngx.log(ngx.ERR, "failed to require resty.redis")
+        return _M.OK
+    end
+    redis.add_commands("ping")
 end
 
-if res and type(res) == "string" then
-    local v = cjson.decode(res)
-    if v and #v > 2 then
-        excess, last, forbidden = v[1], v[2], v[3]
+local _M = { _VERSION = "0.02", OK = 1, BUSY = 2, FORBIDDEN = 3 }
+
+local log_level = ngx.INFO
+
+local function _redis_connect(rds)
+    rds.host = rds.host or "127.0.0.1"
+    rds.port = rds.port or 6379
+    rds.timeout = rds.timeout or 1
+
+    local red = redis:new()
+
+    red:set_timeout(rds.timeout * 1000)
+
+    local r, err
+    if rds.socket then
+        _, err = red:connect(rds.socket)
+        r = rds.socket
+    else
+        _, err = red:connect(rds.host, rds.port)
+        r  = rds.host
     end
 
-    if forbidden == 1 then
-        return {3, excess} -- FORBIDDEN
+    if err then
+        ngx.log(log_level, "failed to connect to redis host: " .. r .. " ", err)
+        return
     end
 
-    local ms = math.abs(now - last)
-    excess = excess - rate * ms / 1000 + 1000
-
-    if excess < 0 then
-        excess = 0
+    if rds.pass then
+        local _, err = red:auth(rds.pass)
+        if err then
+            ngx.log(log_level, "failed to authenticate to redis host" .. r .. " ", err)
+            return
+        end
     end
 
-    if excess > burst then
-        if interval > 0 then
-            local res = redis.pcall('SET', key,
-                                    cjson.encode({excess, now, 1}))
-            if type(res) == "table" and res.err then
-                return {err=res.err}
-            end
+    return red
+end
 
-            local res = redis.pcall('EXPIRE', key, interval)
-            if type(res) == "table" and res.err then
-                return {err=res.err}
-            end
+
+local function _redis_keepalive(conn, timeout, size)
+    local _, err = conn:set_keepalive(timeout, size)
+    if err then
+        ngx.log(log_level, "failed to set keepalive: ", err)
+    end
+end
+
+
+local function _redis_lookup(redis_conn, zone, key, rate, interval, burst)
+    local excess, last, forbidden = 0, 0, 0
+
+    local res, err = redis_conn:get(zone .. ":" .. key)
+    _redis_keepalive(redis_conn, 10000, 100)
+
+    if not res or res == ngx.null then
+        return {_M.OK, excess}
+    end
+
+    if type(res) == "table" and res.err then
+        return {_M.OK, excess}, res.err
+    end
+
+    if type(res) == "string" then
+        local v = cjson.decode(res)
+        if v and #v > 2 then
+            excess, last, forbidden = v[1], v[2], v[3]
         end
 
-        return {2, excess} -- BUSY
-    end
-end
-
-local res = redis.pcall('SET', key, cjson.encode({excess, now, 0}))
-if type(res) == "table" and res.err then
-    return {err=res.err}
-end
-
-local res = redis.pcall('EXPIRE', key, 60)
-if type(res) == "table" and res.err then
-    return {err=res.err}
-end
-
-return {1, excess}
-]==]
-
-
-local function redis_lookup(conn, zone, key, rate, duration, burst)
-    local red = conn
-
-    if not redis_limit_req_script_sha then
-        local res, err = red:script("LOAD", redis_limit_req_script)
-        if not res then
-            return nil, err
+        if forbidden == 1 then
+            return {_M.FORBIDDEN, excess}
         end
 
-        ngx.log(ngx.NOTICE, "load redis limit req script")
+        local now = ngx.now() * 1000
+        local ms = math.abs(now - last)
+        excess = excess - rate * ms / 1000 + 1000
 
-        redis_limit_req_script_sha = res
+        if excess < 0 then
+            excess = 0
+        end
+
+        if excess > burst then
+            return {_M.BUSY, excess}
+        end
     end
 
+    return {_M.OK, excess}
+end
+
+
+local function _redis_update(redis_conn, zone, key, excess, interval, burst)
+    local res, err = nil, nil
     local now = ngx.now() * 1000
 
-    local res, err = red:evalsha(redis_limit_req_script_sha, 5,
-                                 zone .. ":" .. key, rate, now, duration, burst)
-    if not res then
-        redis_limit_req_script_sha = nil
+    if excess > burst and interval > 0 then
+        res, err = redis_conn:setex(zone .. ":" .. key, interval,
+                                          cjson.encode({excess, now, 1}))
+    else
+        res, err = redis_conn:setex(zone .. ":" .. key, 60,
+                                          cjson.encode({excess, now, 0}))
+    end
+
+    _redis_keepalive(redis_conn, 10000, 100)
+
+    if err then
         return nil, err
     end
 
-    -- put it into the connection pool of size 100,
-    -- with 10 seconds max idle timeout
-    local ok, err = red:set_keepalive(10000, 100)
-    if not ok then
-        ngx.log(ngx.WARN, "failed to set keepalive: ", err)
+    if type(res) == "table" and res.err then
+        return nil, res.err
     end
 
-    return res
+    return _M.OK
 end
 
 
 function _M.limit(cfg)
-    if not cfg.conn then
+    if not package.loaded['redis'] then
         local ok, redis = pcall(require, "resty.redis")
         if not ok then
-            ngx.log(ngx.ERR, "failed to require redis")
+            ngx.log(log_level, "failed to require resty.redis")
             return _M.OK
         end
-
-        local rds = cfg.rds or {}
-        rds.timeout = rds.timeout or 1
-        rds.host = rds.host or "127.0.0.1"
-        rds.port = rds.port or 6379
-
-        local red = redis:new()
-
-        red:set_timeout(rds.timeout * 1000)
-
-        local ok, err = red:connect(rds.host, rds.port)
-        if not ok then
-            ngx.log(ngx.WARN, "redis connect err: ", err)
-            return _M.OK
-        end
-
-        if rds.pass then
-            local ok, err = red:auth(rds.pass)
-            if not ok then
-                ngx.log(ngx.ALERT, "Lua failed to authenticate to Redis")
-                return _M.OK
-            end
-        end
-
-        cfg.conn = red
     end
 
-    local conn = cfg.conn
     local zone = cfg.zone or "limit_req"
     local key = cfg.key or ngx.var.remote_addr
     local rate = cfg.rate or "1r/s"
     local burst = cfg.burst * 1000 or 0
     local interval = cfg.interval or 0
-    local log_level = cfg.log_level or ngx.NOTICE
+    log_level = cfg.log_level or log_level
+
+    local conn_masters = {}
+    for i, master in ipairs(cfg.redis.masters) do
+        local host = master["host"]
+        conn_masters[host] = _redis_connect(master)
+        if not conn_masters[host] then
+            ngx.log(log_level, "failed to connect to some or all configured redis masters")
+            return _M.OK
+        end
+    end
+
+    local conn_slave = _redis_connect(cfg.redis.slave)
+    if not conn_slave then
+        ngx.log(log_level, "failed to connect to redis slave")
+        return _M.OK
+    end
 
     local scale = 1
     local len = #rate
@@ -160,17 +174,35 @@ function _M.limit(cfg)
 
     rate = floor((tonumber(rate) or 1) * 1000 / scale)
 
-    local res, err = redis_lookup(conn, zone, key, rate, interval, burst)
+    local res, err = _redis_lookup(conn_slave, zone, key, rate, interval, burst)
     if res and (res[1] == _M.BUSY or res[1] == _M.FORBIDDEN) then
         if res[1] == _M.BUSY then
-            ngx.log(log_level, 'limiting requests, excess ' ..
-                        res[2]/1000 .. ' by zone "' .. zone .. '"')
+            ngx.log(log_level, "excess requests " ..
+                    zone .. ":" .. key .. " - " .. res[2]/1000 )
         end
         return
     end
 
-    if not res and err then
-        ngx.log(ngx.WARN, "redis lookup err: ", err)
+    if not res then
+        ngx.log(log_level, "redis lookup error for key " .. zone .. ":" .. key)
+    end
+
+    for host, conn in pairs(conn_masters) do
+        local _, err = conn:ping()
+        if err then
+            ngx.log(log_level, "failed to ping redis master: " .. host ..
+                              " error: ", err)
+            return _M.OK
+        end
+    end
+
+    for host, conn in pairs(conn_masters) do
+        local _, err = _redis_update(conn, zone, key, res[2], interval, burst)
+        if err then
+            ngx.log(log_level, "failed to update redis master: " .. host ..
+                              " error: ", err)
+            return _M.OK
+        end
     end
 
     return _M.OK


### PR DESCRIPTION
Master will be used for updates.
Slave will be used to get data and calculate action.

I will leave this unmerged until both, awex, **and** hostinger will switch to shared limits.

Related: https://github.com/openresty/lua-resty-redis/pull/117